### PR TITLE
Allow or deny sorting capability on specific models

### DIFF
--- a/docs/sorting/many-to-many.md
+++ b/docs/sorting/many-to-many.md
@@ -91,3 +91,21 @@ class Artist extends Resource
     // ...
 }
 ```
+
+#### Allow or deny sorting on specific models
+
+Allow sorting only on a specific model
+```php
+public $sortable = [
+    'only_sort_on' => \App\Nova\Models\Chapter::class,
+];
+```
+
+Deny sorting on a list of models
+```php
+public $sortable = [
+    'dont_sort_on' => [
+        \App\Nova\Models\Comic::class,
+    ]
+];
+```

--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -19,7 +19,9 @@ trait HasSortableRows
         $model = $resource->resource ?? null;
 
         $sortable = $model->sortable ?? false;
-         if (!key_exists('only_sort_on', $sortable) || $request->viaResource() == $sortable['only_sort_on']) {
+        if (!is_array($sortable) ||
+            !key_exists('only_sort_on', $sortable) ||
+            $request->viaResource() == $sortable['only_sort_on']) {
 
             $sortOnBelongsTo = $resource->disableSortOnIndex ?? false;
 
@@ -41,7 +43,7 @@ trait HasSortableRows
 
             $sortOnHasMany = $sortable['sort_on_has_many'] ?? false;
 
-            if (key_exists('dont_sort_on', $sortable)) {
+            if (is_array($sortable) && key_exists('dont_sort_on', $sortable)) {
                 foreach ($sortable['dont_sort_on'] as $item) {
                     if ($item == $request->viaResource()) {
                         $sortOnBelongsTo = $sortOnHasMany = false;

--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -19,25 +19,39 @@ trait HasSortableRows
         $model = $resource->resource ?? null;
 
         $sortable = $model->sortable ?? false;
-        $sortOnBelongsTo = $resource->disableSortOnIndex ?? false;
+         if (!key_exists('only_sort_on', $sortable) || $request->viaResource() == $sortable['only_sort_on']) {
 
-        if ($request->viaManyToMany()) {
-            $relationshipQuery = $request->findParentModel()->{$request->viaRelationship}();
+            $sortOnBelongsTo = $resource->disableSortOnIndex ?? false;
 
-            if (isset($request->resourceId)) {
-                $tempModel = $relationshipQuery->first()->pivot ?? null;
-                $model = !empty($tempModel) ?
-                    $relationshipQuery->withPivot($tempModel->getKeyName(), $tempModel->sortable['order_column_name'])->find($request->resourceId)->pivot
-                    : null;
-            } else {
-                $model = $relationshipQuery->first()->pivot ?? null;
+            if ($request->viaManyToMany()) {
+                $relationshipQuery = $request->findParentModel()->{$request->viaRelationship}();
+
+                if (isset($request->resourceId)) {
+                    $tempModel = $relationshipQuery->first()->pivot ?? null;
+                    $model = !empty($tempModel) ?
+                        $relationshipQuery->withPivot($tempModel->getKeyName(), $tempModel->sortable['order_column_name'])->find($request->resourceId)->pivot
+                        : null;
+                } else {
+                    $model = $relationshipQuery->first()->pivot ?? null;
+                }
+
+                $sortable = $model->sortable ?? false;
+                $sortOnBelongsTo = !empty($sortable);
             }
 
-            $sortable = $model->sortable ?? false;
-            $sortOnBelongsTo = !empty($sortable);
-        }
+            $sortOnHasMany = $sortable['sort_on_has_many'] ?? false;
 
-        $sortOnHasMany = $sortable['sort_on_has_many'] ?? false;
+            if (key_exists('dont_sort_on', $sortable)) {
+                foreach ($sortable['dont_sort_on'] as $item) {
+                    if ($item == $request->viaResource()) {
+                        $sortOnBelongsTo = $sortOnHasMany = false;
+                        break;
+                    }
+                }
+            }
+        } else {
+            $sortOnBelongsTo = $sortOnHasMany = false;
+        }
 
         return (object) [
             'model' => $model,


### PR DESCRIPTION
This PR adds the ability to specify on a sortable model which other models the list should or shouldn't be sorted on via the use of the `$sortable` list keys `only_sort_on` or `dont_sort_on`

For example in a `A` HasMany `B` HasMany `C`

`A` contain a HasMany `B` as well as a HasManyThrough `C`

You don't want to sort `C` via the `A` relationship that the HasManyThrough provides.