### PR TITLE
Check if we are sorting the correct model

### DIFF
--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -81,15 +81,19 @@ trait HasSortableRows
         $sortability = static::getSortability($request);
 
         if (!empty($sortability)) {
-            $shouldSort = true;
-            if (empty($sortability->sortable)) $shouldSort = false;
-            if ($sortability->sortOnBelongsTo && empty($request->viaResource())) $shouldSort = false;
-            if ($sortability->sortOnHasMany && empty($request->viaResource())) $shouldSort = false;
 
-            if (empty($request->get('orderBy')) && $shouldSort) {
-                $query->getQuery()->orders = [];
-                $orderColumn = !empty($sortability->sortable['order_column_name']) ? $sortability->sortable['order_column_name'] : 'sort_order';
-                return $query->orderBy($orderColumn);
+            //  make sure we are querying the same table
+            if ($query->getQuery()->from == $sortability->model->getTable()) {
+                $shouldSort = true;
+                if (empty($sortability->sortable)) $shouldSort = false;
+                if ($sortability->sortOnBelongsTo && empty($request->viaResource())) $shouldSort = false;
+                if ($sortability->sortOnHasMany && empty($request->viaResource())) $shouldSort = false;
+
+                if (empty($request->get('orderBy')) && $shouldSort) {
+                    $query->getQuery()->orders = [];
+                    $orderColumn = !empty($sortability->sortable['order_column_name']) ? $sortability->sortable['order_column_name'] : 'sort_order';
+                    return $query->orderBy($orderColumn);
+                }
             }
         }
 


### PR DESCRIPTION
I have some pretty complicated database relationships and when working with `HasSortableManyToManyRows`, it is sorting in the wrong model.

Sorting ManyToMany is working fine for Course and Module. But when I try to add a topic via modules details, it is calling the  `HasSortableRows::indexQuery` which have `$request->viaResource()` = 'Module' and `$query` is for Topics. 

Here is a sample link when the sorting of wrong model is happening.
```
https://homestead.sample/boss/resources/topics/new?viaResource=modules&viaResourceId=1&viaRelationship=topics 
```

```php
class Module extends Resource
{
    use HasSortableManyToManyRows;

    public function fields(Request $request)
    {
        return [
            BelongsToMany::make('Courses'),

            HasMany::make('Topics'),
    }
}
```

```php
class Course extends Resource
{
   public function fields(Request $request)
    {
        return [
            ID::make()
                ->sortable(),

            BelongsToMany::make('Modules'),

             // ...
        ];
    }
}
```

```php
class Topic extends Resource
{
    use HasSortableRows;

    public function fields(Request $request)
    {
        return [
            ID::make()
                ->sortable(),

            BelongsTo::make('Module')
                ->sortable(),

            Text::make('Name')
                ->sortable()
                ->rules('required', 'max:255'),
           // ...
        ];
    }
```

Since Module will use a Pivot for sorting, the Module table itself won't have a `sort` column. So adding  a topic via Module's detail page(HasMany::make('Topics')) will show an error.

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'sort' in 'order clause' (SQL: select * from `modules` order by `sort` asc)
```