### PR TITLE
allow specifying which request is sortable

### DIFF
--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -6,8 +6,17 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 
 trait HasSortableRows
 {
+    public static function canSort(NovaRequest $request)
+    {
+        return true;
+    }
+
     public static function getSortability(NovaRequest $request)
     {
+        if (!static::canSort($request)) {
+            return null;
+        }
+
         $model = null;
 
         try {
@@ -65,6 +74,10 @@ trait HasSortableRows
     public function serializeForIndex(NovaRequest $request, $fields = null)
     {
         $sortability = static::getSortability($request);
+
+        if (is_null($sortability)) {
+            return parent::serializeForIndex($request, $fields);
+        }
 
         return array_merge(parent::serializeForIndex($request, $fields), [
             'sortable' => $sortability->sortable,


### PR DESCRIPTION
Similar to #37 I also need a way to specify per request if a sort can be allowed.

With this PR the user can add a `canSort()` method on the resource which gets passed the `NovaRequest` and returns a boolean. It returns `true` by default.

```php
public static function canSort(NovaRequest $request)
{
        return $request->user()->hasRole('admin');
}
```