### PR TITLE
Implement global spatie configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ class SomeModel extends Eloquent implements Sortable
 }
 ```
 
+When the model does not have a sortable configuration, the default eloquent-sortable configuration will be used.
+
 ### Apply HasSortableRows to Nova resource
 
 Apply `HasSortableRows` trait from this package on the Resource:
@@ -110,6 +112,20 @@ public $sortable = [
   'order_column_name' => 'sort_order',
   'sort_when_creating' => true,
   'sort_on_has_many' => true,
+];
+```
+
+The sort on has many configuration can be apply in a per model basis or it can be added in the eloquent-sortable configuration for all the models.
+
+```php
+return [
+
+    // Spatie sortable configuration
+
+    /**
+     * Add sort on has many in all the models.
+     **/
+    'sort_on_has_many' => true,
 ];
 ```
 

--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -2,8 +2,8 @@
 
 namespace OptimistDigital\NovaSortable\Http\Controllers;
 
-use Laravel\Nova\Nova;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Nova;
 use OptimistDigital\NovaSortable\Traits\HasSortableRows;
 
 class SortableController
@@ -82,7 +82,7 @@ class SortableController
 
         $model = $models->first();
         $modelKeyName = $model->getKeyName();
-        $orderColumnName = !empty($model->sortable['order_column_name']) ? $model->sortable['order_column_name'] : 'sort_order';
+        $orderColumnName = $model->determineOrderColumnName();
 
         // Sort orderColumn values
         $sortedOrder = $models->pluck($orderColumnName)->sort()->values();


### PR DESCRIPTION
The *HasSortableRows* trait takes the model configuration from the spatie configuration file if the model does not have a sortable property instead of checking if the model has the sortable property.

This way the model configuration can be in the eloquent-sortable configuration file and it is not necessary to be set up.

Every time the package needs the *order_column_name* the spatie method *determineOrderColumnName()* is used for full compatibility.