### PR TITLE
Provide a sensible fallback when no previous sorting values were defined

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -86,10 +86,12 @@ class SortableController
 
         // Sort orderColumn values
         $sortedOrder = $models->pluck($orderColumnName)->sort()->values();
+        $increment = 0;
         foreach ($resourceIds as $i => $id) {
             $_model = $models->firstWhere($modelKeyName, $id);
-            $_model->{$orderColumnName} = $sortedOrder[$i];
+            $_model->{$orderColumnName} = $sortedOrder[$i] ?? $increment;
             $_model->save();
+            ++$increment;
         }
 
         return response('', 204);


### PR DESCRIPTION
This PR provides a sensible fallback for those cases where you add sortable behaviour on existing resources and the values of the sortable column is null. 

With the previous code, there would be no update as you would again set the value of the sorting column to null. With the new code, the value of the sorting column will be the value of `$increment`. 