### PR TITLE
Fixes incorrect primary key for related model

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -39,7 +39,7 @@ class SortableController
 
             if (!empty($relatedModel)) {
                 $orderColumnName = $relatedModel->determineOrderColumnName();
-                $relatedKeyName = $relatedModel->getKeyName();
+                $relatedKeyName = $relatedModels->first()->getKeyName();
 
                 // Sort orderColumn values
                 if ($relationshipType === 'belongsToMany' || $relationshipType === 'morphToMany') {


### PR DESCRIPTION
For belongsToMany relationship it was using "key" column name from the pivot table instead of related model