### PR TITLE
Recursively detect Spatie's SortableTrait

### DIFF
--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -135,7 +135,7 @@ trait HasSortableRows
         if (is_null($model)) return null;
 
         // Check if spatie trait is in the model.
-        if (!in_array(SortableTrait::class, array_keys((new \ReflectionClass($model))->getTraits()))) {
+        if (! in_array(SortableTrait::class, class_uses_recursive($model))) {
             return null;
         }
 


### PR DESCRIPTION
Hi,
When using Spatie's `SortableTrait` inside custom traits, detection fails and nova sortable is not initialized.

Here is an example:
```php
trait SortableOnManyTrait
{
    use \Spatie\EloquentSortable\SortableTrait;

    public array $sortable = [
        'order_column_name' => 'order_column',
        'sort_when_creating' => true,
        'sort_on_has_many' => true,
    ];
}
```
Thanks!