### PR TITLE
Allow sort in resource index by desc

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -20,6 +20,11 @@ class SortableController
         $viaRelationship = $request->input('viaRelationship');
         $relationshipType = $request->input('relationshipType');
 
+        // Reverse the array if it is configured to order by DESC.
+        if (HasSortableRows::getOrderByDirection($validationResult->sortable) === 'DESC') {
+          $resourceIds = array_reverse($resourceIds);
+        }
+
         // Relationship sorting
         if (!empty($viaResource)) {
             $resourceClass = Nova::resourceForKey($viaResource);
@@ -133,14 +138,16 @@ class SortableController
     public function moveToStart(NovaRequest $request)
     {
         $validationResult = $this->validateRequest($request);
-        $validationResult->model->moveToStart();
+        $method = HasSortableRows::getOrderByDirection($validationResult->sortable) !== 'DESC' ? 'moveToStart' : 'moveToEnd';
+        $validationResult->model->{$method}();
         return response('', 204);
     }
 
     public function moveToEnd(NovaRequest $request)
     {
         $validationResult = $this->validateRequest($request);
-        $validationResult->model->moveToEnd();
+        $method = HasSortableRows::getOrderByDirection($validationResult->sortable) !== 'DESC' ? 'moveToEnd' : 'moveToStart';
+        $validationResult->model->{$method}();
         return response('', 204);
     }
 
@@ -171,4 +178,5 @@ class SortableController
         }
         return $improvedSortedOrder;
     }
+
 }

--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -125,7 +125,8 @@ trait HasSortableRows
 
                 if (empty($request->get('orderBy')) && $shouldSort) {
                     $query->getQuery()->orders = [];
-                    return $query->orderBy($sortability->model->determineOrderColumnName());
+                    $direction = static::getOrderByDirection($sortability->sortable);
+                    return $query->orderBy($sortability->model->determineOrderColumnName(), $direction);
                 }
             }
         }
@@ -152,5 +153,17 @@ trait HasSortableRows
         if (!isset($model->sortable)) return $defaultConfiguration;
 
         return array_merge($defaultConfiguration, $model->sortable);
+    }
+
+  /**
+   * Get the orderBy direction.
+   */
+    public static function getOrderByDirection($config)
+    {
+        $order = 'ASC';
+        if (isset($config['nova_order_by'])) {
+            $order = strtoupper($config['nova_order_by']);
+        }
+        return $order;
     }
 }


### PR DESCRIPTION
As discussed in issue https://github.com/optimistdigital/nova-sortable/issues/94 this PR will allow to define the direction of the sort. Allowing the resource index to be ordered by `desc`.

I will be more than happy to receive feedbacks.