### PR TITLE
Added table name to order by query

### DIFF
--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -133,7 +133,8 @@ trait HasSortableRows
                 if (empty($request->get('orderBy')) && $shouldSort) {
                     $query->getQuery()->orders = [];
                     $direction = static::getOrderByDirection($sortability->sortable);
-                    return $query->orderBy($sortability->model->determineOrderColumnName(), $direction);
+                    $queryColumn = "{$sortability->model->getTable()}.{$sortability->model->determineOrderColumnName()}";
+                    return $query->orderBy($queryColumn, $direction);
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue I had where the column used in the `orderBy` query is ambiguous. The `getTable()` method is added to specify which column the query should use.