### PR TITLE
Fix: Since symfony/http-foundation 7.4: Request::get() is deprecated

### DIFF
--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -142,7 +142,7 @@ trait HasSortableRows
                     $shouldSort = false;
                 }
 
-                if (empty($request->get('orderBy')) && $shouldSort) {
+                if (empty($request->input('orderBy')) && $shouldSort) {
                     $query->getQuery()->orders = [];
                     $direction = static::getOrderByDirection($sortability->sortable);
                     $queryColumn = "{$sortability->model->getTable()}.{$sortability->model->determineOrderColumnName()}";


### PR DESCRIPTION
Since Symfony 7.4, the get method is depricated as it can be seen here:
https://github.com/symfony/http-foundation/blob/977a554a34cf8edc95ca351fbecb1bb1ad05cc94/Request.php#L742

This cascades to Laravel's Illuminate\Http\Request and further extends to FormRequest, as it can be seen here:
https://github.com/laravel/framework/blob/93686c3b428bdc0d3a1ec7c2d7024869252b3e28/src/Illuminate/Http/Request.php#L427-L440